### PR TITLE
Mobile Speed Insights

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,9 +3,10 @@ import { URL_MAPPINGS } from './src/lib/config/redirect-config';
 
 const cspHeader = `
     default-src 'self';
-    script-src 'self' 'unsafe-eval' 'unsafe-inline' 
+    script-src 'self' 'unsafe-eval' 'unsafe-inline'
         static.cloudflareinsights.com challenges.cloudflare.com *.cloudflare.com
-        *.vercel-insights.com *.vercel-analytics.com https://vercel.live *.vercel.app;
+        *.vercel-insights.com *.vercel-analytics.com https://vercel.live *.vercel.app
+        'wasm-unsafe-eval';
     style-src 'self' 'unsafe-inline'
         https://vercel.live;
     img-src 'self' blob: data:
@@ -21,7 +22,10 @@ const cspHeader = `
         https://vercel.live;
     connect-src 'self'
         cloudflareinsights.com challenges.cloudflare.com *.cloudflare.com
-        *.vercel-insights.com *.vercel-analytics.com vitals.vercel-insights.com https://vercel.live *.vercel.app wss://ws-us3.pusher.com;
+        *.vercel-insights.com *.vercel-analytics.com vitals.vercel-insights.com
+        https://vercel.live *.vercel.app wss://ws-us3.pusher.com
+        https://vitals.vercel-analytics.com;
+    worker-src 'self' blob:;
     upgrade-insecure-requests;
 `;
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,6 +39,12 @@ export default function RootLayout({
               href="https://vitals.vercel-analytics.com"
               crossOrigin="anonymous"
             />
+            {/* Speed Insights script preload for mobile */}
+            <link
+              rel="modulepreload"
+              href="/_vercel/speed-insights/script.js"
+              crossOrigin="anonymous"
+            />
           </>
         )}
 


### PR DESCRIPTION
security: update CSP headers to include 'wasm-unsafe-eval' and allow Vercel Analytics connections