### PR TITLE
feat: adopt JSON-LD @graph pattern with stable @ids

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,11 +1,14 @@
 import Image from 'next/image';
 
+import { StructuredData, buildProfilePageNode } from '@/components/seo/structured-data';
 import { BorderedSection } from '@/components/ui/bordered-section';
 import { SectionHeader } from '@/components/ui/section-header';
 import { PAGE_STAGGER_DELAYS } from '@/constants/config/animation-config';
 import { PAGE_METADATA } from '@/constants/config/site-metadata';
 import { SOCIAL_LINKS_DATA } from '@/constants/config/social-config';
 import { EXPERIENCES, EDUCATION, ABOUT_CONTENT, SKILLS } from '@/constants/pages/about-page';
+import { PERSONAL_INFO, PAGE_DESCRIPTIONS } from '@/constants/shared';
+import { INTERNAL_ROUTES } from '@/constants/urls';
 import { getSocialIcon } from '@/utils/social-icons';
 
 import type { Metadata } from 'next';
@@ -22,6 +25,16 @@ export const metadata: Metadata = PAGE_METADATA.ABOUT;
 export default function AboutPage(): JSX.Element {
   return (
     <main className="container mx-auto max-w-6xl px-4 py-16">
+      <StructuredData
+        id="structured-data-about"
+        nodes={[
+          buildProfilePageNode({
+            path: INTERNAL_ROUTES.ABOUT,
+            name: `About ${PERSONAL_INFO.FULL_NAME}`,
+            description: PAGE_DESCRIPTIONS.ABOUT_PAGE_INTRO,
+          }),
+        ]}
+      />
       {/* Hero Section - Editorial style */}
       <section className="relative mb-24">
         <div className="mb-12 grid grid-cols-1 gap-8 md:grid-cols-3">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ export default function RootLayout({
   return (
     <html lang="en" className="h-full">
       <head>
-        <StructuredData pageType="website" />
+        <StructuredData websiteVariant="full" />
         {/* Preconnect hints for analytics domains */}
         {shouldEnableAnalytics && (
           <link

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -2,6 +2,11 @@ import { ExternalLink, GitFork, Star } from 'lucide-react';
 import Link from 'next/link';
 import { z } from 'zod';
 
+import {
+  StructuredData,
+  buildCollectionPageNode,
+  buildSoftwareApplicationNode,
+} from '@/components/seo/structured-data';
 import { BorderedSection } from '@/components/ui/bordered-section';
 import { Card } from '@/components/ui/card';
 import { SectionHeader } from '@/components/ui/section-header';
@@ -10,6 +15,7 @@ import { EXTERNAL_API } from '@/constants/config/external-api-config';
 import { GITHUB_CONFIG } from '@/constants/config/github-config';
 import { PAGE_METADATA } from '@/constants/config/site-metadata';
 import { PORTFOLIO_PAGE, PORTFOLIO_CONTENT } from '@/constants/pages/portfolio-page';
+import { INTERNAL_ROUTES } from '@/constants/urls';
 import { GITHUB_REPO_SCHEMA } from '@/types/api-types';
 
 import type { GitHubRepo } from '@/types/api-types';
@@ -101,6 +107,17 @@ export default async function PortfolioPage(): Promise<JSX.Element> {
 
   return (
     <main className="container mx-auto max-w-7xl px-4 py-16">
+      <StructuredData
+        id="structured-data-portfolio"
+        nodes={[
+          buildCollectionPageNode({
+            path: INTERNAL_ROUTES.PORTFOLIO,
+            name: PORTFOLIO_PAGE.HEADING,
+            description: PORTFOLIO_CONTENT.HERO_SUBTITLE,
+          }),
+          ...projects.map(buildSoftwareApplicationNode),
+        ]}
+      />
       {/* Hero Section - Editorial */}
       <section className="relative mb-16">
         <div className="space-y-6">

--- a/src/components/seo/structured-data.tsx
+++ b/src/components/seo/structured-data.tsx
@@ -1,48 +1,58 @@
-import Script from 'next/script';
-
 import { SEO_DATA } from '@/constants/config/seo-config';
 import { PERSONAL_INFO, PAGE_DESCRIPTIONS, PROFESSIONAL_TITLES } from '@/constants/shared';
 import { EXTERNAL_URLS, ALL_PLATFORMS } from '@/constants/urls';
 
+import type { GitHubRepo } from '@/types/api-types';
 import type { JSX } from 'react';
 
+type GraphNode = Record<string, unknown>;
+
 type StructuredDataProps = {
-  readonly pageType?: 'website' | 'person' | 'article';
-  readonly title?: string;
-  readonly description?: string;
-  readonly url?: string;
+  readonly nodes?: readonly GraphNode[];
+  readonly websiteVariant?: 'full' | 'slim';
+  readonly includePerson?: boolean;
+  readonly id?: string;
 };
 
-/**
- * Structured Data (JSON-LD) component for enhanced SEO
- */
-export function StructuredData({
-  pageType = 'website',
-  title,
-  description,
-  url = EXTERNAL_URLS.MAIN,
-}: StructuredDataProps): JSX.Element {
-  const baseStructuredData = {
-    '@context': 'https://schema.org',
-    '@type': pageType === 'person' ? 'Person' : 'WebSite',
-    name: title ?? `${PERSONAL_INFO.FULL_NAME} - ${PROFESSIONAL_TITLES.CURRENT}`,
-    description: description ?? PAGE_DESCRIPTIONS.SEO_DESCRIPTION,
-    url,
-    author: {
-      '@type': 'Person',
-      name: PERSONAL_INFO.FULL_NAME,
-      url: EXTERNAL_URLS.MAIN,
-      sameAs: ALL_PLATFORMS,
-    },
-  };
+const ROOT = EXTERNAL_URLS.MAIN;
+const INLANG = 'en';
 
-  const personStructuredData = {
-    '@context': 'https://schema.org',
+export const SCHEMA_IDS = {
+  website: `${ROOT}/#website`,
+  person: `${ROOT}/#person`,
+  webpage: (path: string) => `${ROOT}${path}#webpage`,
+  project: (slug: string) => `${ROOT}/#project-${encodeURIComponent(slug)}`,
+} as const;
+
+function buildWebsiteNode(variant: 'full' | 'slim'): GraphNode {
+  if (variant === 'slim') {
+    return {
+      '@type': 'WebSite',
+      '@id': SCHEMA_IDS.website,
+      url: `${ROOT}/`,
+      name: PERSONAL_INFO.FULL_NAME,
+    };
+  }
+  return {
+    '@type': 'WebSite',
+    '@id': SCHEMA_IDS.website,
+    url: `${ROOT}/`,
+    name: PERSONAL_INFO.FULL_NAME,
+    alternateName: SEO_DATA.ALTERNATE_NAMES,
+    description: PAGE_DESCRIPTIONS.SEO_DESCRIPTION,
+    inLanguage: INLANG,
+    publisher: { '@id': SCHEMA_IDS.person },
+  };
+}
+
+function buildPersonNode(): GraphNode {
+  return {
     '@type': 'Person',
+    '@id': SCHEMA_IDS.person,
+    url: `${ROOT}/`,
     name: PERSONAL_INFO.FULL_NAME,
     alternateName: SEO_DATA.ALTERNATE_NAMES,
     description: PAGE_DESCRIPTIONS.ABOUT_PAGE_INTRO,
-    url: EXTERNAL_URLS.MAIN,
     image: EXTERNAL_URLS.OG_IMAGE,
     jobTitle: PROFESSIONAL_TITLES.CURRENT,
     worksFor: {
@@ -52,16 +62,89 @@ export function StructuredData({
     knowsAbout: SEO_DATA.KNOWS_ABOUT,
     sameAs: ALL_PLATFORMS,
   };
+}
 
-  const structuredData = pageType === 'person' ? personStructuredData : baseStructuredData;
+export function buildProfilePageNode({
+  path,
+  name,
+  description,
+}: {
+  readonly path: string;
+  readonly name: string;
+  readonly description?: string;
+}): GraphNode {
+  return {
+    '@type': 'ProfilePage',
+    '@id': SCHEMA_IDS.webpage(path),
+    url: `${ROOT}${path}`,
+    isPartOf: { '@id': SCHEMA_IDS.website },
+    mainEntity: { '@id': SCHEMA_IDS.person },
+    name,
+    ...(description !== undefined && { description }),
+    inLanguage: INLANG,
+  };
+}
+
+export function buildCollectionPageNode({
+  path,
+  name,
+  description,
+}: {
+  readonly path: string;
+  readonly name: string;
+  readonly description?: string;
+}): GraphNode {
+  return {
+    '@type': 'CollectionPage',
+    '@id': SCHEMA_IDS.webpage(path),
+    url: `${ROOT}${path}`,
+    isPartOf: { '@id': SCHEMA_IDS.website },
+    about: { '@id': SCHEMA_IDS.person },
+    name,
+    ...(description !== undefined && { description }),
+    inLanguage: INLANG,
+  };
+}
+
+export function buildSoftwareApplicationNode(project: GitHubRepo): GraphNode {
+  // GitHub URLs are https://github.com/<owner>/<repo>; namespace the @id with
+  // owner so two repos with the same name from different orgs can't collide.
+  const ownerRepo = project.html_url.replace(/^https?:\/\/github\.com\//, '');
+  return {
+    '@type': 'SoftwareApplication',
+    '@id': SCHEMA_IDS.project(ownerRepo),
+    url: project.html_url,
+    name: project.name,
+    description: project.description ?? `${project.name} — open source project`,
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: 'All',
+    creator: { '@id': SCHEMA_IDS.person },
+    sameAs: [project.html_url],
+    ...(project.language !== null && { programmingLanguage: project.language }),
+    isAccessibleForFree: true,
+  };
+}
+
+export function StructuredData({
+  nodes = [],
+  websiteVariant = 'slim',
+  includePerson = true,
+  id = 'structured-data',
+}: StructuredDataProps): JSX.Element {
+  const graph: GraphNode[] = [buildWebsiteNode(websiteVariant)];
+  if (includePerson) graph.push(buildPersonNode());
+  graph.push(...nodes);
+
+  const document = {
+    '@context': 'https://schema.org',
+    '@graph': graph,
+  };
 
   return (
-    <Script
-      id="structured-data"
+    <script
+      id={id}
       type="application/ld+json"
-      dangerouslySetInnerHTML={{
-        __html: JSON.stringify(structuredData),
-      }}
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(document) }}
     />
   );
 }


### PR DESCRIPTION
## Summary

Refactors structured data per the hawksley.dev guide (https://hawksley.dev/blog/json-ld-explained-for-personal-websites/) so crawlers can build a unified knowledge-graph view of the site instead of seeing duplicated standalone nodes per page.

- Single `@graph` document per page with stable `@id` fragments (`/#website`, `/#person`, `/<path>#webpage`, `/#project-<owner>/<repo>`)
- `WebSite` emits a slim variant on non-root pages (same `@id`, dedupes via graph-merge) and a full variant in the root layout with `publisher → Person` linkage, `alternateName`, and `inLanguage`
- `ProfilePage` node on `/about` with `mainEntity → Person` (Google's recommended shape for author/about pages)
- `CollectionPage` node on `/portfolio` with `about → Person`, plus one `SoftwareApplication` per fetched GitHub repo — generated server-side from the same `getGitHubRepos()` data the page already renders. Uses `isAccessibleForFree: true` for FOSS rather than `offers: { price: 0 }` to avoid misleading "Free of charge" rich-result treatment
- Switched from `next/script` to a plain `<script>` tag because Next's `<Script>` was deferring the JSON-LD into the RSC payload (`$21` reference) instead of the initial HTML — crawlers couldn't see it

## Test plan

- [x] `npm run build` clean: 29 tests pass, ESLint clean, TypeScript clean, all 11 routes prerender
- [x] Local dev server: curled `/`, `/about`, `/portfolio` and confirmed the rendered `@graph` shape, including 4 `SoftwareApplication` nodes from live GitHub data on `/portfolio`
- [ ] After deploy, validate each page in Google's [Rich Results Test](https://search.google.com/test/rich-results) and the [Schema Markup Validator](https://validator.schema.org)

🤖 Generated with [Claude Code](https://claude.com/claude-code)